### PR TITLE
Get profile via DID

### DIFF
--- a/background.js
+++ b/background.js
@@ -24,11 +24,11 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
 chrome.action.onClicked.addListener((tab) => {
   if (tabsWithDID.has(tab.id)) {
-    chrome.tabs.sendMessage(tab.id, { type: "GET_DOMAIN" }, (response) => {
-      if (response && response.domain) {
-        const newUrl = `${bskyAppUrl}/profile/${response.domain}`
-        chrome.tabs.create({ url: newUrl })
-      }
-    })
+    chrome.tabs.sendMessage(tab.id, { type: "GET_DID" }, function (response) {
+        if (response && response.did) {
+          const newUrl = `${bskyAppUrl}/profile/${response.did}`
+          chrome.tabs.create({ url: newUrl })
+        }
+      })
   }
 })

--- a/content.js
+++ b/content.js
@@ -1,3 +1,5 @@
+var data
+
 function getDomainName() {
   const hostname = window.location.hostname
   return hostname.replace(/^www\./, "")
@@ -7,7 +9,7 @@ async function checkForDID(domain) {
   const response = await fetch(
     `https://dns.google/resolve?name=_atproto.${domain}&type=TXT`
   )
-  const data = await response.json()
+  data = await response.json()
   const records = data?.Answer?.filter((record) => record.type === 16) || []
   return records.some((record) => record.data.includes("did=did:plc:"))
 }
@@ -23,8 +25,17 @@ async function checkForDID(domain) {
   }
 })()
 
+function getDID(domain) {
+  const records = data?.Answer?.filter((record) => record.type === 16) || []
+  console.log(records.filter((record) => record.data.includes("did=did:plc:"))[0]["data"])
+  return records.filter((record) => record.data.includes("did=did:plc:"))[0]["data"].substring(4)
+}
+
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === "GET_DOMAIN") {
     sendResponse({ domain: getDomainName() })
+  }
+  if (message.type === "GET_DID") {
+    sendResponse({ did: getDID(getDomainName()) })
   }
 })


### PR DESCRIPTION
Tweaked existing code to: 1) extract the DID associated with a domain from its TXT record (if present), and 2) use the DID when attempting to access a profile (instead of assuming that the profile's name is the domain name). This means that it will work properly on domains which point to a profile whose handle *isn't* the domain name; an edge case, but one that I've seen a few people use for name redirects.

Probably I've done at least three stupid things here: I am not particularly good at writing javascript, and this is my first time poking at a chrome extension. This does work in my testing, though! So it can't be *that* stupid.