### PR TITLE
feat: update link to use DID instead of domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- use DID for profile url instead of domain name
+
 ## [1.0.1] - 2023-04-30
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2023-05-03
+
 - use DID for profile url instead of domain name
 
 ## [1.0.1] - 2023-04-30

--- a/background.js
+++ b/background.js
@@ -1,4 +1,4 @@
-const tabsWithDID = new Set()
+const tabsWithDID = new Map()
 
 const bskyAppUrl = "https://staging.bsky.app"
 
@@ -15,7 +15,7 @@ chrome.runtime.onInstalled.addListener(() => {
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === "DID_FOUND") {
     setIcon(sender.tab.id, "logo48.png")
-    tabsWithDID.add(sender.tab.id)
+    tabsWithDID.set(sender.tab.id, message.did)
   } else {
     setIcon(sender.tab.id, "logo48_gray.png")
     tabsWithDID.delete(sender.tab.id)
@@ -23,12 +23,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 })
 
 chrome.action.onClicked.addListener((tab) => {
-  if (tabsWithDID.has(tab.id)) {
-    chrome.tabs.sendMessage(tab.id, { type: "GET_DOMAIN" }, (response) => {
-      if (response && response.domain) {
-        const newUrl = `${bskyAppUrl}/profile/${response.domain}`
-        chrome.tabs.create({ url: newUrl })
-      }
-    })
+  const did = tabsWithDID.get(tab.id)
+  if (did) {
+    const newUrl = `${bskyAppUrl}/profile/${did}`
+    chrome.tabs.create({ url: newUrl })
   }
 })

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "SkyLink - Bluesky DID Detector",
   "short_name": "SkyLink",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "author": "jesse@adhdjesse.com",
   "action": {
     "default_icon": { "48": "logo48_gray.png", "128": "logo128_gray.png" }


### PR DESCRIPTION
Uses the DID for a profile link instead of the domain.

This allows people to add their DID to multiple domains, and all of them work to find the correct Bluesky profile.