### PR TITLE
Fix missed chrome.runtime in PR #5.

### DIFF
--- a/content.js
+++ b/content.js
@@ -39,9 +39,9 @@ function performAction(privacyConsentAccepted) {
         const did = await checkForDID(domain)
 
         if (did) {
-          chrome.runtime.sendMessage({ type: "DID_FOUND", did })
+          runtime.sendMessage({ type: "DID_FOUND", did })
         } else {
-          chrome.runtime.sendMessage({ type: "DID_NOT_FOUND" })
+          runtime.sendMessage({ type: "DID_NOT_FOUND" })
         }
       })();
 


### PR DESCRIPTION
These should have both been just runtime (since we define runtime in the header of the file to support multibrowser).

The danger of last minute ninja commits. 🥳