### PR TITLE
remove “tabs” from permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for alternative HTTPS method for detecting DID
 
+### Changed
+
+- Remove permissions for "tabs" as it is not needed
+
 ## [1.2.0] - 2023-05-03
 
 ### Added

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -15,7 +15,7 @@
     "128": "logo128.png"
   },
   "description": "Detects Decentralized Identifiers (DIDs) in a domain's TXT records and links to the associated Bluesky profile.",
-  "permissions": ["activeTab", "tabs", "management", "storage", "<all_urls>"],
+  "permissions": ["activeTab", "management", "storage", "<all_urls>"],
   "content_security_policy": "script-src 'self'; object-src 'self'",
   "background": {
     "scripts": ["background.js"]

--- a/manifest.json
+++ b/manifest.json
@@ -9,7 +9,7 @@
   },
   "icons": { "48": "logo48.png", "128": "logo128.png" },
   "description": "Detects Decentralized Identifiers (DIDs) in a domain's TXT records and links to the associated Bluesky profile.",
-  "permissions": ["activeTab", "tabs", "storage", "management"],
+  "permissions": ["activeTab", "storage", "management"],
   "background": { "service_worker": "background.js" },
   "content_scripts": [{ "matches": ["<all_urls>"], "js": ["content.js"] }]
 }


### PR DESCRIPTION
Looks like we no longer need the "tabs" permission.

This closes #19 