### PR TITLE
Fixing bug caused by browser extension idle/sleep (1.4.1 release candidate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Small fix for a bug introduced in `1.4.0` that occurs when the browser puts idle extensions to sleep
+
 ## [1.4.0]
 
 ### Changed
 
 - Migrate/refactor everything from `content.js` into a self-contained `background.js`
 - Swap `activeTab` permission for `tabs` so that we can drop the `<all_urls>` permission
-- Remove permissions for "management" as it is not needed
+- Remove permissions for `management` as it is not needed
 - Migrate Firefox to Manifest v3 (but this means the minimum FF version is now 109)
 - Input validation for domains and DIDs (security enhancement)
 - Replace `staging.bsky.app` with `bsky.app`


### PR DESCRIPTION
This PR fixes a small bug introduced by the transition to a `background.js` only model in `1.4.0`:

Background scripts are not able to maintain persistence; and after 30-90 seconds of inactivity (browser dependent), they will be stopped. This is great in theory, since it reduces resources used by idle scripts.

In practice, this means that if you load up a website (e.g. `bsky.app`) that has a DID record, it will detect the DID, light up blue, become clickable, and everything functions as normal. 

However if you keep browsing on the same tab/domain for a while before you notice that it's lit up, the extension goes to sleep and loses the DID cache. The icon stays blue, but clicking it does nothing because cache state is lost.

Refreshing a page or opening the page in a new tab reactivates the extension and it once against functions normally.

The fix in this PR expects this behavior (sleep/cache loss), and in cases where the icon is blue but the extension has gone to sleep, will allow a click to still function in opening a new tab with the profile by invoking `performAction` again, repopulating the DID cache, then opening the discovered DID in a new tab.