### PR TITLE
shrink the manifes descriptions to fit under 132

### DIFF
--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -14,7 +14,7 @@
     "48": "logo48.png",
     "128": "logo128.png"
   },
-  "description": "Detects Decentralized Identifiers (DIDs) in a domain's TXT records and .well-known/atproto-did files, linking to the associated Bluesky profile.",
+  "description": "Detects Bluesky DIDs in domain TXT records and .well-known/atproto-did files, linking to the associated profile.",
   "permissions": ["tabs", "storage"],
   "host_permissions": ["https://*/*"],
   "content_security_policy": {

--- a/manifest.json
+++ b/manifest.json
@@ -8,7 +8,7 @@
     "default_icon": { "48": "logo48_gray.png", "128": "logo128_gray.png" }
   },
   "icons": { "48": "logo48.png", "128": "logo128.png" },
-  "description": "Detects Decentralized Identifiers (DIDs) in a domain's TXT records and .well-known/atproto-did files, linking to the associated Bluesky profile.",
+  "description": "Detects Bluesky DIDs in domain TXT records and .well-known/atproto-did files, linking to the associated profile.",
   "permissions": ["tabs", "storage"],
   "host_permissions": ["https://*/*"],
   "background": { "service_worker": "background.js" }


### PR DESCRIPTION
Fix this error when uploading to Chrome:

```
There was a problem uploading your file. Please try again.
The description field in manifest is too long: 144. It exceeds maximum size limit of 132 characters.
```